### PR TITLE
Add btn as per pico-8 docs.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -266,6 +266,20 @@ local function newAPI(noFS,sprsheetmap)
     return false, false
   end
 
+  -- should allow customizing this
+  local button_mapping = {
+    -- player 1
+    {{"left"}, {"right"}, {"up"}, {"down"}, {"z", "c", "x"}, {"x", "v", "m"}},
+    -- player 2
+    {{"s"}, {"f"}, {"e"}, {"d"}, {"lshift", "tab"}, {"a", "q"}}}
+
+  function api.btn(n, p)
+    local keys = button_mapping[(p or 0) + 1][n+1]
+    if(keys) then
+      return love.keyboard.isDown(unpack(keys))
+    end
+  end
+
   function api.getMPos()
     return _ScreenToLiko(love.mouse.getPosition())
   end


### PR DESCRIPTION
Having this as a global feels wrong; I feel like `api.lua` would be better if it just returned a table that was cloned by `r.newGlobals` in `runtime.lua` but I didn't want to make that change before talking about it with you.
