### PR TITLE
Fix textbuffer to use existing keymap lookup functions.

### DIFF
--- a/editor/code.lua
+++ b/editor/code.lua
@@ -10,6 +10,13 @@ comment = _GetColor(14),
 str = _GetColor(13),
 }
 
+function cedit:_init(editor)
+  self:resetBuffer()
+  self.keymap = self.keymap or {}
+  self.parent = self.buffer
+  self.buffer.parent = editor
+end
+
 function cedit:resetBuffer()
   self.buffer = api.TextBuffer(1,2,47,14,0,0,0)
   function self.buffer:_redraw() --To add syntax highlighting
@@ -79,10 +86,6 @@ function cedit:_mmove(x,y,dx,dy,it,iw)
   end
 end
 
-function cedit:_kpress(k,sc,ir)
-  self.buffer:_kpress(k,sc,ir)
-end
-
 function cedit:_tinput(t)
   self.buffer:_tinput(t)
 end
@@ -92,7 +95,5 @@ function cedit:_tpress()
   --self.lineLimit = 7
   api.showkeyboard(true)
 end
-
-cedit:resetBuffer()
 
 return cedit

--- a/editor/init.lua
+++ b/editor/init.lua
@@ -10,7 +10,7 @@ function Editor:_init()
   self:switchEditor(self.curid)
   for _,e in pairs(Editor.editors) do
     local m = require("editor."..e)
-    if m._init then m:_init() end
+    if m._init then m:_init(Editor) end
     if not m.keymap then m.keymap = {} end
     if not m.parent then m.parent = Editor end
   end
@@ -90,13 +90,13 @@ local key_for = function(k)
   return k
 end
 
-local function find_binding(key, mode)
+function Editor.find_binding(key, mode)
   if mode.keymap[key] then return mode.keymap[key], mode end
-  if mode.parent then return find_binding(key, mode.parent) end
+  if mode.parent then return Editor.find_binding(key, mode.parent) end
 end
 
 function Editor:_kpress(k,sc,ir)
-  local command, mode = find_binding(key_for(k), self.Current)
+  local command, mode = Editor.find_binding(key_for(k), self.Current)
   if command then
     command(mode)
     mode:_redraw()

--- a/libraries/textbuffer.lua
+++ b/libraries/textbuffer.lua
@@ -116,14 +116,6 @@ function tb:_redraw()
   end
 end
 
-function tb:_kpress(k,sc,ir)
-  if self.keymap[k] then
-    self.keymap[k](self,ir)
-    self:_redraw()
-  end
-  self:forceBlink()
-end
-
 function tb:_tinput(t)
   self:forceBlink()
   --print(self.buffer[self.cursorY]:sub(0,self.cursorX-1)..t..self.buffer[self.cursorY]:sub(self.cursorX,-1))


### PR DESCRIPTION
Textbuffer is a parent mode of code (and eventually of console/terminal).

Fixes #23.
