### PR TITLE
Fix a bug where resetting the buffer didn't update the code editor keymap parent.

### DIFF
--- a/editor/code.lua
+++ b/editor/code.lua
@@ -10,15 +10,15 @@ comment = _GetColor(14),
 str = _GetColor(13),
 }
 
-function cedit:_init(editor)
+function cedit:_init()
   self:resetBuffer()
   self.keymap = self.keymap or {}
-  self.parent = self.buffer
-  self.buffer.parent = editor
 end
 
 function cedit:resetBuffer()
   self.buffer = api.TextBuffer(1,2,47,14,0,0,0)
+  self.parent = self.buffer
+  self.buffer.parent = require("editor")
   function self.buffer:_redraw() --To add syntax highlighting
     api.rect(1,9,192,128-16,6) api.color(7)
     local dbuff, gx,gy, sr = self:getLinesBuffer()


### PR DESCRIPTION
This is a bit confusing because it's easy to think of the text buffer
as a data structure, not an editor mode, but it's kind of acting as
both. If it were just a data structure, it wouldn't handle key
bindings, but if it were just an editor mode, it wouldn't get replaced
when a new cart gets loaded.
