### PR TITLE
Add copy/paste and flip/rotate to sprite editor.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -162,7 +162,11 @@ local function newAPI(noFS,sprsheetmap,carttilemap)
   function api.ImageData:initialize(w,h) if h then self.imageData = love.image.newImageData(w or 192, h or 128) elseif type(w) == "string" then self.imageData = love.image.newImageData(love.filesystem.newFileData(w,"spritemap","base64")) else self.imageData = w end end
   function api.ImageData:size() return self.imageData:getDimensions() end
   function api.ImageData:getPixel(x,y) return self.imageData:getPixel((x or 1)-1,(y or 1)-1) end
-  function api.ImageData:setPixel(x,y,c) self.imageData:setPixel((x or 1)-1,(y or 1)-1,unpack(_GetColor(c))) return self end
+  function api.ImageData:setPixel(x,y,c)
+    if(type(c) ~= "table") then c = _GetColor(c) end -- accept palette color or {r,g,b}
+    self.imageData:setPixel((x or 1)-1,(y or 1)-1,unpack(c))
+    return self
+  end
   function api.ImageData:map(mf)
     self.imageData:mapPixel(
       function(x,y,r,g,b,a)

--- a/editor/sprite.lua
+++ b/editor/sprite.lua
@@ -193,6 +193,21 @@ end
 
 local clipboard = nil
 
+local make_transformation = function(lookup)
+  return function()
+    local current = api.SpriteMap:extract(sprsid)
+    local data = api.SpriteMap:data()
+    local qx,qy = api.SpriteMap:rect(sprsid)
+    for x=1,imgw do
+      for y=1,imgh do
+        data:setPixel(qx+x-1,qy+y-1,{current:getPixel(lookup(x,y))})
+      end
+    end
+    api.SpriteMap.img = data:image()
+    s:redrawSPR() s:redrawSPRS()
+  end
+end
+
 s.keymap = {
   ["ctrl-c"] = function()
     clipboard = api.SpriteMap:extract(sprsid)
@@ -210,6 +225,11 @@ s.keymap = {
     api.SpriteMap.img = data:image()
     s:redrawSPR() s:redrawSPRS()
   end,
+
+  -- TODO: find better key bindings
+  ["ctrl-r"] = make_transformation(function(x,y) return y,9-x end),
+  ["ctrl-h"] = make_transformation(function(x,y) return 9-x,y end),
+  ["ctrl-f"] = make_transformation(function(x,y) return x,9-y end),
 }
 
 return s

--- a/editor/sprite.lua
+++ b/editor/sprite.lua
@@ -191,4 +191,25 @@ function s:_mrelease(x,y,b,it)
   end
 end
 
+local clipboard = nil
+
+s.keymap = {
+  ["ctrl-c"] = function()
+    clipboard = api.SpriteMap:extract(sprsid)
+  end,
+
+  ["ctrl-v"] = function()
+    if not clipboard then return end
+    local data = api.SpriteMap:data()
+    local qx,qy = api.SpriteMap:rect(sprsid)
+    for x=1,imgw do
+      for y=1,imgh do
+        data:setPixel(qx+x-1,qy+y-1,{clipboard:getPixel(x,y)})
+      end
+    end
+    api.SpriteMap.img = data:image()
+    s:redrawSPR() s:redrawSPRS()
+  end,
+}
+
 return s


### PR DESCRIPTION
Only works by copying entire sprites, not rectangles within them.

Fixes #19 and #20.
