### PR TITLE
Allow setting scale from an environment variable.

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -1,4 +1,4 @@
-_ScreenScale = 3
+_ScreenScale = tonumber(os.getenv("LIKO_SCALE") or 3)
 
 function love.conf(t)
     t.identity = ".liko12"              -- The name of the save directory (string)


### PR DESCRIPTION
This allows the scale to be configured.

It would be nice if the size of the window could be controlled from `~/.liko12/init.lua` but I couldn't find a way to do this that scaled the drawing to match.
