### PR TITLE
Double path dir after error

### DIFF
--- a/terminal_commands.lua
+++ b/terminal_commands.lua
@@ -40,7 +40,6 @@ function CMD.run(command,...)
   if not ok then
     _auto_exitgame()
     tout("ERR: "..err,9)
-    tout(term.rootDir.."> ",8,true)
   else
     _auto_switchgame()
   end


### PR DESCRIPTION
Typing anything in code editor and running it will display an error. Game will exit and terminal will print out your dir path two times.

For example: 
- Type in code editor:
  `asdasd`
- Now, type run in terminal.
- Game crash and you will see:
  `/> />` 

This patch will make terminal display `/>` only once.
