### PR TITLE
DiskOS terminal: insert newline after Enter

### DIFF
--- a/OS/DiskOS/Programs/apis.lua
+++ b/OS/DiskOS/Programs/apis.lua
@@ -1,7 +1,6 @@
 --Print the list of functions for a peripheral, or all peripherals
 local _,perlist = coroutine.yield("BIOS:listPeripherals")
 
-print("")
 palt(0,false) --Make black opaque
 
 local peri = select(1,...)

--- a/OS/DiskOS/Programs/cd.lua
+++ b/OS/DiskOS/Programs/cd.lua
@@ -1,9 +1,8 @@
 --Enter a specifiec directory/path/drive
 local args = {...} --Get the arguments passed to this program
-if #args < 1 then color(8) print("\nMust provide the path") return end
+if #args < 1 then color(8) print("Must provide the path") return end
 local tar = table.concat(args," ") --The path may include whitespaces
 local term = require("C://terminal")
-print("") --A new line
 
 tar = term.parsePath(tar)
 

--- a/OS/DiskOS/Programs/drives.lua
+++ b/OS/DiskOS/Programs/drives.lua
@@ -1,6 +1,5 @@
 --Lists the available virtual drives
 local dr = fs.drives()
 for drive, data in pairs(dr) do
-  print("\n"..drive.." - "..data.usage.."/"..data.size.." Byte ("..(math.floor((((data.usage*100)/data.size)*100))/100).."%)",false)
+  print(drive.." - "..data.usage.."/"..data.size.." Byte ("..(math.floor((((data.usage*100)/data.size)*100))/100).."%)\n",false)
 end
-print("")-- A new line

--- a/OS/DiskOS/Programs/edit.lua
+++ b/OS/DiskOS/Programs/edit.lua
@@ -1,5 +1,4 @@
 --Text editor--
-print("")
 local args = {...} --Get the arguments passed to this program
 if #args < 1 then color(8) print("Must provide the path to the file") return end
 local tar = table.concat(args," ") --The path may include whitespaces

--- a/OS/DiskOS/Programs/export.lua
+++ b/OS/DiskOS/Programs/export.lua
@@ -3,7 +3,7 @@ local destination = select(1,...)
 local term = require("C://terminal")
 local eapi = require("C://Editors")
 
-if not destination then color(8) print("\nMust provide the destination file path") return end
+if not destination then color(8) print("Must provide the destination file path") return end
 
 destination = term.parsePath(destination)
 
@@ -12,15 +12,15 @@ if fs.exists(destination) and fs.isDirectory(destination) then color(8) print("D
 if destination:sub(-4,-1) == ".png" then --Sprite Map Exporting.
   if select(2,...) == "-opaque" then
     fs.write(destination,eapi.leditors[3].SpriteMap.img:data():exportOpaque())
-    color(11) print("\nExported Opaque Spritesheet successfully")
+    color(11) print("Exported Opaque Spritesheet successfully")
   else
     fs.write(destination,eapi.leditors[3].SpriteMap.img:data():export())
-    color(11) print("\nExported Spritesheet successfully")
+    color(11) print("Exported Spritesheet successfully")
   end
 elseif destination:sub(-4,-1) == ".lua" then --Lua code Exporting.
   fs.write(destination,eapi.leditors[2]:export())
-  color(11) print("\nExported Luacode successfully")
+  color(11) print("Exported Luacode successfully")
 else --Unknown
-  color(8) print("\nUnknown exporte extension")
+  color(8) print("Unknown exporte extension")
 end
 

--- a/OS/DiskOS/Programs/folder.lua
+++ b/OS/DiskOS/Programs/folder.lua
@@ -1,5 +1,4 @@
 --Opens the host file explorer in the current active folder
 
 local term = require("C://terminal")
-print("")
 openAppData("/drives/"..term.getdrive()..term.getdirectory())

--- a/OS/DiskOS/Programs/ftest.lua
+++ b/OS/DiskOS/Programs/ftest.lua
@@ -19,4 +19,4 @@ elseif mode == "write" then
   fs.write(dest,fimg)
 end
 
-print("\n Done")
+print(" Done")

--- a/OS/DiskOS/Programs/gdebugclip.lua
+++ b/OS/DiskOS/Programs/gdebugclip.lua
@@ -1,4 +1,3 @@
-print("")
 local data = clipboard()
 data = math.b64dec(data)
 data = math.decompress(data,"lz4")

--- a/OS/DiskOS/Programs/help.lua
+++ b/OS/DiskOS/Programs/help.lua
@@ -27,7 +27,6 @@ end
 
 helpPath = require("C://Programs/help",true).getHelpPath() --A smart way to keep the helpPath
 
-print("") --New line
 palt(0,false) --Make black opaque
 
 local doc --The help document to print

--- a/OS/DiskOS/Programs/import.lua
+++ b/OS/DiskOS/Programs/import.lua
@@ -12,8 +12,6 @@ local sw, sh = screenSize()
 if source then source = term.parsePath(source) end
 if destination then destination = term.parsePath(destination) end
 
-print("") --New line
-
 if not source then color(8) print("Must provide path to the source file") return end
 if not fs.exists(source) then color(8) print("Source doesn't exists") return end
 if fs.isDirectory(source) then color(8) print("Source can't be a directory") return end

--- a/OS/DiskOS/Programs/load.lua
+++ b/OS/DiskOS/Programs/load.lua
@@ -5,8 +5,6 @@ local eapi = require("C://Editors")
 
 if source and source ~= "@clip" then source = term.parsePath(source)..".lk12" elseif source ~= "@clip" then source = eapi.filePath end
 
-print("") --NewLine
-
 if not source then color(8) print("Must provide path to the file to load") return end
 if source ~= "@clip" and not fs.exists(source) then color(8) print("File doesn't exists") return end
 if source ~= "@clip" and fs.isDirectory(source) then color(8) print("Couldn't load a directory !") return end

--- a/OS/DiskOS/Programs/ls.lua
+++ b/OS/DiskOS/Programs/ls.lua
@@ -2,7 +2,7 @@
 local term = require("C://terminal") --Require the terminal api.
 local path = term.getpath() --Get the current active directory.
 local files = fs.directoryItems(path) --Returns a table containing the names of folders and files in the given directory
-print("") --A new line
+
 for k, f in ipairs(files) do
   color(fs.isFile(path..f) and 7 or 11)
   print(f.." ",false)

--- a/OS/DiskOS/Programs/mkdir.lua
+++ b/OS/DiskOS/Programs/mkdir.lua
@@ -1,9 +1,8 @@
 --Create a new directory/folder
 local args = {...} --Get the arguments passed to this program
-if #args < 1 then color(8) print("\nMust provide the directory name") return end
+if #args < 1 then color(8) print("Must provide the directory name") return end
 local tar = table.concat(args," ") --The path may include whitespaces
 local term = require("C://terminal")
-print("") --A new line
 
 tar = term.parsePath(tar)
 

--- a/OS/DiskOS/Programs/new.lua
+++ b/OS/DiskOS/Programs/new.lua
@@ -1,4 +1,4 @@
 local eapi = require("C://Editors")
 eapi.filePath = nil
 eapi:clearData()
-color(11) print("\nCleared editors data successfully")
+color(11) print("Cleared editors data successfully")

--- a/OS/DiskOS/Programs/paint.lua
+++ b/OS/DiskOS/Programs/paint.lua
@@ -1,5 +1,4 @@
 --Paint Program--
-print("")
 local args = {...}
 if #args < 1 then color(8) print("Must provide the path to the file") return end
 local tar = table.concat(args," ")..".lk12" --The path may include whitespaces
@@ -24,6 +23,7 @@ if not fs.exists(tar) then --Create a new image
   if not height or height:len() == 0 then print("") return end
   local h = tonumber(height)
   if not h then color(8) print("\nInvalid Height: "..height..", height must be a number !") return end
+  print("")
   
   imgdata = imagedata(w,h)
   img = imgdata:image()

--- a/OS/DiskOS/Programs/peripherals.lua
+++ b/OS/DiskOS/Programs/peripherals.lua
@@ -1,7 +1,6 @@
 --List the available peripherals
 local _,perlist = coroutine.yield("BIOS:listPeripherals")
 
-print("") --New line
 for per, functions in pairs(perlist) do
  print(per.." ", false)
 end

--- a/OS/DiskOS/Programs/portCart.lua
+++ b/OS/DiskOS/Programs/portCart.lua
@@ -11,8 +11,6 @@ local source = select(1,...)
 
 if source then source = term.parsePath(source)..".lk12" end
 
-print("") --NewLine
-
 if not source then color(8) print("Must provide path to the file to port") return end
 if not fs.exists(source) then color(8) print("File doesn't exists") return end
 if fs.isDirectory(source) then color(8) print("Couldn't port a directory !") return end

--- a/OS/DiskOS/Programs/reboot.lua
+++ b/OS/DiskOS/Programs/reboot.lua
@@ -1,8 +1,8 @@
 local args = {...} --Get the arguments passed to this program
 if tostring(args[1] or "soft") == "hard" then
-  print("\nHARD REBOOTING ...") sleep(0.25)
+  print("HARD REBOOTING ...") sleep(0.25)
   reboot(true)
 else
-  print("\nSOFT REBOOTING ...") sleep(0.25)
+  print("SOFT REBOOTING ...") sleep(0.25)
   reboot(false)
 end

--- a/OS/DiskOS/Programs/rm.lua
+++ b/OS/DiskOS/Programs/rm.lua
@@ -1,9 +1,8 @@
 --Remove/delete a specific file
 local args = {...} --Get the arguments passed to this program
-if #args < 1 then color(8) print("\nMust provide the path") return end
+if #args < 1 then color(8) print("Must provide the path") return end
 local tar = table.concat(args," ") --The path may include whitespaces
 local term = require("C://terminal")
-print("") --A new line
 
 local function index(path,notfirst)
   color(7)

--- a/OS/DiskOS/Programs/run.lua
+++ b/OS/DiskOS/Programs/run.lua
@@ -2,7 +2,6 @@
 
 --First we will start by obtaining the disk data
 --We will run the current code in the editor
-print("")
 local eapi = require("C://Editors")
 local mapobj = require("C://Libraries/map")
 

--- a/OS/DiskOS/Programs/save.lua
+++ b/OS/DiskOS/Programs/save.lua
@@ -10,7 +10,7 @@ if destination and destination ~= "@clip" then destination = term.parsePath(dest
   destination = eapi.filePath
 end
 
-if not destination then color(8) print("\nMust provide the destination file path") return end
+if not destination then color(8) print("Must provide the destination file path") return end
 
 if destination ~= "@clip" and fs.exists(destination) and fs.isDirectory(destination) then color(8) print("Destination must not be a directory") return end
 
@@ -19,12 +19,12 @@ local sw, sh = screenSize()
 if string.lower(flag) == "--sheet" then --Sheet export
   local data = eapi.leditors[3]:export(true)
   if destination == "@clip" then clipboard(data) else fs.write(destination,data) end
-  color(11) print("\nExported Spritesheet successfully")
+  color(11) print("Exported Spritesheet successfully")
   return
 elseif string.lower(flag) == "--code" then
   local data = eapi.leditors[2]:export(true)
   if destination == "@clip" then clipboard(data) else fs.write(destination:sub(0,-6),data) end
-  color(11) print("\nExported Lua code successfully")
+  color(11) print("Exported Lua code successfully")
   return
 end
 
@@ -46,4 +46,4 @@ else
   fs.write(destination,header.."\n"..data)
 end
 
-color(11) print(destination == "@clip" and "\nSaved to clipboard successfully" or "\nSaved successfully")
+color(11) print(destination == "@clip" and "Saved to clipboard successfully" or "Saved successfully")

--- a/OS/DiskOS/Programs/update_disk.lua
+++ b/OS/DiskOS/Programs/update_disk.lua
@@ -5,8 +5,6 @@ local eapi = require("C://Editors")
 
 if source then source = term.parsePath(source)..".lk12" else source = eapi.filePath end
 
-print("") --NewLine
-
 if not source then color(8) print("Must provide path to the file to update") return end
 if not fs.exists(source) then color(8) print("File doesn't exists") return end
 if fs.isDirectory(source) then color(8) print("Couldn't load a directory !") return end

--- a/OS/DiskOS/terminal.lua
+++ b/OS/DiskOS/terminal.lua
@@ -113,7 +113,7 @@ function term.parsePath(path)
 end
 
 function term.execute(command,...)
-  if not command then print("") return false, "No command" end
+  if not command then return false, "No command" end
   if fs.exists(curpath..command..".lua") then
     local chunk, err = fs.load(curpath..command..".lua")
     if not chunk then color(8) print("\nL-ERR:"..tostring(err)) color(7) return false, tostring(err) end
@@ -137,7 +137,7 @@ function term.execute(command,...)
       end
     end
   end
-  color(9) print("\nFile not found") color(7) return false, "File not found"
+  color(9) print("File not found") color(7) return false, "File not found"
 end
 
 function term.loop() --Enter the while loop of the terminal
@@ -156,6 +156,7 @@ function term.loop() --Enter the while loop of the terminal
         if hispos then table.remove(history,#history) hispos = false end
         table.insert(history, buffer)
         blink = false; checkCursor()
+        print("") -- insert newline after Enter
         term.execute(split(buffer)) buffer = ""
         color(7) checkCursor() print(term.getpath().."> ",false) blink = true cursor("none")
       elseif a == "backspace" then


### PR DESCRIPTION
As discussed in discord, I think it makes more sense to insert the newline in the terminal.lua after Enter.

Having to take care of adding the newline in every program every time is too much trouble for what is worth, and if a program forgets to add the newline it would mess up the terminal.
I even found a case (in [save.lua](https://github.com/RamiLego4Game/LIKO-12/blob/0c460eeb1e014ab8c92ecbe95fed66d54636892a/OS/DiskOS/Programs/save.lua#L15)) where someone forgot to add a leading "\n" to an error string.

I think I've changed all the instances of programs that added newlines at the start.
I also added a newline that was needed in paint.lua after the width/height input.