### PR TITLE
Code editor: add kill, yank/paste, delete, smarter indentation and smart tab

### DIFF
--- a/OS/DiskOS/Editors/code.lua
+++ b/OS/DiskOS/Editors/code.lua
@@ -161,21 +161,34 @@ function ce:gotoEndLine()
   self:drawLineNum()
 end
 
-function ce:insertNewLine()
-  local newLine = buffer[self.cy]:sub(self.cx,-1)
-  buffer[self.cy] = buffer[self.cy]:sub(0,self.cx-1)
-  local snum = string.find(buffer[self.cy].."a","%S") --Number of spaces
-  snum = snum and snum-1 or 0
-  newLine = string.rep(" ",snum)..newLine
-  self.cx, self.cy = snum+1, self.cy+1
-  if self.cy > #buffer then
+-- Will indent the given line based on the previous line
+-- returns the amount of leading whitespaces after indentation
+function ce:indent(y)
+  local wspace = ""
+  if y > 1 then -- check the indentation of the previous line
+    wspace = buffer[y-1]:match("^ *")
+  end
+  -- increase indentation if opening a new level in code
+  if buffer[y-1]:find('then *$')
+    or buffer[y-1]:find('do *$')
+    or buffer[y-1]:find("function.*%) *$")
+    or buffer[y-1]:find("[[{%(]$")
+    then wspace = wspace.."  "
+  end
+  buffer[y] = buffer[y]:gsub("^ *",wspace)
+  return wspace:len()
+end
+
+-- Inserts a newline in the given position, splitting the line in two if needed
+-- you should execute self:drawBuffer() and self:drawLineNum() after this
+function ce:insertNewLineAt(x,y)
+  local newLine = buffer[y]:sub(x,-1)
+  buffer[y] = buffer[y]:sub(0,x-1)
+  if y+1 > #buffer then
     table.insert(buffer,newLine)
   else
-    buffer = lume.concat(lume.slice(buffer,0,self.cy-1),{newLine},lume.slice(buffer,self.cy,-1)) --Insert between 2 different lines
+    buffer = lume.concat(lume.slice(buffer,0,y),{newLine},lume.slice(buffer,y+1,-1)) --Insert between 2 different lines
   end
-  self:checkPos()
-  self:drawBuffer()
-  self:drawLineNum()
 end
 
 -- Delete the char from the given coordinates.
@@ -209,13 +222,15 @@ function ce:pasteText()
   local firstLine = true
   for line in string.gmatch(text.."\n", "([^\r\n]*)\r?\n") do
     if not firstLine then
-      self:insertNewLine() self.cx=1
+      self:insertNewLineAt(self.cx,self.cy)
+      self.cx, self.cy = 1, self.cy+1
     else
       firstLine = false
     end
     self:textinput(line)
   end
-  if self:checkPos() then self:drawBuffer() else self:drawLine() end
+  self:checkPos()
+  self:drawBuffer()
   self:drawLineNum()
 end
 
@@ -223,7 +238,14 @@ end
 ce.lastKey = ""
 
 ce.keymap = {
-  ["return"] = ce.insertNewLine,
+  ["return"] = function(self)
+    self:insertNewLineAt(self.cx,self.cy)
+    local indent = self:indent(self.cy+1)
+    self.cx, self.cy = indent+1, self.cy+1
+    self:checkPos()
+    self:drawBuffer()
+    self:drawLineNum()
+  end,
 
   ["left"] = function(self)
     local flag = false
@@ -300,7 +322,19 @@ ce.keymap = {
   end,
 
   ["tab"] = function(self)
-    self:textinput(" ")
+    -- indent if pressing tab only once, with cursor placed before the first word
+    if self.lastKey ~= "tab" and buffer[self.cy]:sub(0,self.cx):find("^ *$") then
+        local indent = self:indent(self.cy)
+        if indent > 0 then
+          self.cx = indent+1
+          if self:checkPos() then self:drawBuffer() else self:drawLine() end
+          self:drawLineNum()
+        else -- insert space anyway if there's no indentation at all
+          self:textinput(" ")
+        end
+    else
+      self:textinput(" ")
+    end
   end,
 
   ["ctrl-a"] = ce.gotoStartLine,

--- a/OS/DiskOS/Editors/init.lua
+++ b/OS/DiskOS/Editors/init.lua
@@ -243,8 +243,16 @@ function edit:loop() --Starts the while loop
           end
         end
         
-        if self.leditors[self.active].keymap and self.leditors[self.active].keymap[key] then self.leditors[self.active].keymap[key](self.leditors[self.active],c)
-        elseif self.leditors[self.active].keymap and self.leditors[self.active].keymap[sc] then self.leditors[self.active].keymap[sc](self.leditors[self.active],c) end
+        if self.leditors[self.active].keymap then
+          local usedKey
+          if self.leditors[self.active].keymap[key] then usedKey = key
+          elseif self.leditors[self.active].keymap[sc] then usedKey = sc
+          end
+          if usedKey then
+            self.leditors[self.active].keymap[usedKey](self.leditors[self.active], c)
+            self.leditors[self.active].lastKey = usedKey
+          end
+        end
         if self.leditors[self.active][event] then self.leditors[self.active][event](self.leditors[self.active],a,b,c,d,e,f) end
       end
     elseif event == "mousepressed" then

--- a/OS/DiskOS/Programs/edit.lua
+++ b/OS/DiskOS/Programs/edit.lua
@@ -58,16 +58,16 @@ local controls = {
     if fs.exists(tar) then texteditor:import(fs.read(tar)) end
     texteditor:entered()
   end,
-  
+
   function() --Save
     local data = texteditor:export()
     fs.write(tar,data)
   end,
-  
+
   function() --Exit
     texteditor:leaved()
     return true
-  end 
+  end
 }
 
 for event, a,b,c,d,e,f in pullEvent do
@@ -112,9 +112,17 @@ for event, a,b,c,d,e,f in pullEvent do
         key = "shift-" .. key
         sc = "shift-" .. sc
       end
-      
-      if texteditor.keymap and texteditor.keymap[key] then texteditor.keymap[key](texteditor,c)
-      elseif texteditor.keymap and texteditor.keymap[sc] then texteditor.keymap[sc](texteditor,c) end
+
+      if texteditor.keymap then
+        local usedKey
+        if texteditor.keymap[key] then usedKey = key
+        elseif texteditor.keymap[sc] then usedKey = sc
+        end
+        if usedKey then
+          texteditor.keymap[usedKey](texteditor,c)
+          texteditor.lastKey = usedKey
+        end
+      end
       if texteditor[event] then texteditor[event](texteditor,a,b,c,d,e,f) end
     end
   elseif event == "mousepressed" and not eflag then


### PR DESCRIPTION
This adds a basic form of cut and paste similar to what is found in
readline default mappings: http://readline.kablamo.org/emacs.html

I also wrote a more generic way to remove a character in a particular position to handles all the edge cases when deleting a newline causes two lines to be merged, and I added a binding for "delete".

There's also now a "lastKey" property in the code editor that should contain the last used value for the keymap. This must be assigned by the editor that uses the code.lua api.

Imho, I think it would make sense to move the logic in editor.lua that chooses to call the keymap function to the code.lua.
Implementations of other editors using code.lua can simply override/change the keymap or use a custom event handling function if they want to customize parts of it, imho.