### PR TITLE
help: only ask input if scrolling past the screen

### DIFF
--- a/OS/DiskOS/Programs/help.lua
+++ b/OS/DiskOS/Programs/help.lua
@@ -13,15 +13,15 @@ local giveApi = select(2,...)
 
 if type(giveApi) == "boolean" then --Requesting HELP api
   local api = {}
-  
+
   function api.setHelpPATH(p)
 	helpPath = p
   end
-  
+
   function api.getHelpPath()
 	return helpPath
   end
-  
+
   return api
 end
 
@@ -36,7 +36,7 @@ for path in nextPath() do
 	local files = fs.directoryItems(path)
     for _,file in ipairs(files) do
       if file == topic then
-		doc = path..topic break
+        doc = path..topic break
       end
     end
     if doc then break end
@@ -45,6 +45,8 @@ end
 
 if not doc then color(8) print("Help file not found '"..topic.."' !") return end
 
+-- Waits for any input (keyboard or mouse) to continue
+-- Returns true if "q" was pressed, to quit
 local function waitkey()
   while true do
     local name, a = pullEvent()
@@ -62,31 +64,41 @@ printCursor(0) --Set the x pos to 0 (the start of the screen)
 
 local tw, th = termSize()
 local sw, sh = screenSize()
+local _, top = printCursor()
 local msg = "[press any key to continue, q to quit]"
 local msglen = msg:len()
 
-local function sprint(text) --Smart print with the "press any key to continue" message
+-- Smart print with the "press any key to continue" message
+-- Returns true if "q" was pressed, which should abort the process
+local function sprint(text)
   local cx, cy = printCursor()
-  
+
   local txtlen = text:len()
   local txth = math.ceil(txtlen/tw)
   local txtw = text:sub((txth-1)*tw, -1)
-  
-  if cy + txth < th then print(text) return end
+
+  -- print text directly if it won't scroll the content past the screen
+  if top - txth > 0 then
+    print(text)
+    top = top - txth
+    sleep(0.02) -- a short delay helps following the output
+    return
+  end
+
   for i=1, txth do
-	printCursor(0)
-	if cy + i < th then
-	  print(text:sub( (i-1)*tw+1, (i)*tw ))
-	else
-	  pushColor() color(9)
-	  print(msg,false) popColor()
-    flip()
-    local quit = waitkey()
-    printCursor(0,th-1)
-    rect(0,sh-9,sw,8,false,0)
-    if quit then return true end
-    print(text:sub( (i-1)*tw+1, (i)*tw ))
-	end
+    printCursor(0)
+    if cy + i < th then
+      print(text:sub( (i-1)*tw+1, (i)*tw ))
+    else
+      pushColor() color(9)
+      print(msg,false) popColor()
+      flip()
+      local quit = waitkey()
+      printCursor(0,th-1)
+      rect(0,sh-9,sw,8,false,0)
+      if quit then return true end
+      print(text:sub( (i-1)*tw+1, (i)*tw ))
+    end
   end
 end
 


### PR DESCRIPTION
Currently you get the "press any key to continue" message as soon as you
reach the end of the screen, which is immediately if the cursor is
already at the end.

With this change, the content will scroll the screen up until the point
when it wouldn't fit entirely in a single screen. Just like the "more"
program worked in DOS (except that one only asked once per entire page).

I also added a very short delay when outputing lines, for nicer feedback