### PR TITLE
Terminal: load init from autoexec.lua if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,8 @@ luac.out
 *.db
 
 # Releases
-/builds/
+/builds
+
+# User Configuration files
+/OS/DiskOS/autoexec.lua
+


### PR DESCRIPTION
If an autoexec.lua file exists in the root of the disk, DiskOS will load it during the initialization of the terminal, instead of the welcome text.

This allows users to customize the welcome screen or add other initialization. So the OS can do something different on welcome.

The printing of the prompt was made into the method term.prompt so it can be redefined if wanted.

Also refactored some duplicated code from term.execute