### PR TITLE
Fix syntax parsing

### DIFF
--- a/OS/DiskOS/Libraries/parser/languages/lua.lua
+++ b/OS/DiskOS/Libraries/parser/languages/lua.lua
@@ -40,6 +40,7 @@ function token(stream, state)
       elseif char == "\"" or char == "'" then
         state.starter = char
         state.tokenizer = "string"
+        return "string" -- Return immediatelly so quotes doesn't get affected by escape sequences
       -- Decimal numbers
       elseif char == '.' and stream:match('%d+') then
           result = 'number'
@@ -60,6 +61,7 @@ function token(stream, state)
       -- Multiline string matching
       elseif char == "[" and stream:eat("%[") then
           state.tokenizer = "multilineString"
+          return "string"
       -- Keyword matching                
       elseif char:find('[%w_]') then
           stream:eatWhile('[%w_]')


### PR DESCRIPTION
Fix a bug in the string parser where the opening quotation marks are
included in the first token returned.

![screenshot_1](https://user-images.githubusercontent.com/7695608/29251230-b017dd06-8027-11e7-91e6-11afb0f9f45b.png)
