### PR TITLE
Implemented undo/redo in the code editor

### DIFF
--- a/OS/DiskOS/Editors/code.lua
+++ b/OS/DiskOS/Editors/code.lua
@@ -518,7 +518,6 @@ ce.keymap = {
   end,
 
   ["backspace"] = function(self)
-    -- TODO: wrap this in an undo group
     if self.sxs then self:deleteSelection() return end
     if self.cx == 1 and self.cy == 1 then return end
     local lineChange
@@ -529,7 +528,6 @@ ce.keymap = {
   end,
 
   ["delete"] = function(self)
-    -- TODO: wrap this in an undo group
     if self.sxs then self:deleteSelection() return end
     local lineChange
     self.cx, self.cy, lineChange = self:deleteCharAt(self.cx,self.cy)


### PR DESCRIPTION
This adds Ctrl-Z and Shift-Ctrl-Z as hotkeys for undo/redo in the code editor. It restores the cursor position and selection just like a real text editor should. It stores a complete snapshot of the editor's data at each edit, which may be quite inefficient. If you think this will be a problem, then each edit operation could store a shorter segment of just the part that changed with start,end indices.

Also, note that I only did this for the code editor but this could be extended to the other editors as well. However, I suspect that each editor should have its own independent undo stack so you don't undo a sprite edit while looking at your code or vice versa.
