### PR TITLE
Prevent deleting drives when using rm

### DIFF
--- a/OS/DiskOS/Programs/rm.lua
+++ b/OS/DiskOS/Programs/rm.lua
@@ -12,17 +12,25 @@ local term = require("terminal")
 local function index(path,notfirst)
   color(9)
   if fs.isFile(path) then print("Deleted "..path) fs.delete(path) return end
+  
   local items = fs.getDirectoryItems(path)
   for k, item in ipairs(items) do
-    if fs.isDirectory(path..item) then
-      print("Entering directory "..path..item.."/") pullEvent()
-      index(path..item.."/",true)
+    if fs.isDirectory(path.."/"..item) then
+      print("Entering directory "..path.."/"..item.."/") pullEvent()
+      index(path.."/"..item, true)
     else
-      print("Deleted "..path..item) pullEvent()
-      fs.delete(path..item)
+      print("Deleted "..path.."/"..item) pullEvent()
+      fs.delete(path.."/"..item)
     end
   end
   local isDir = fs.isDirectory(path)
+  
+  if path:sub(-2, -1) == ":/" or path:sub(-3, -1) == ":/*" then
+     color(8)
+     print("Can't remove top level directory!")
+     return
+  end
+  
   fs.delete(path)
   if not notfirst then color(11) print("Deleted "..(isDir and "Directory" or "File").." successfully") end
   return true


### PR DESCRIPTION
There's a bug involving rm that will delete the entire drive if you attempt to do something like:

```
cd D:/
rm *
```

This checks if the path it's attempting to delete is at the top level and stops if it's true. I've also added some slashes between folder names and files to fix recursive deletion.