### PR TITLE
Fix crash on reflash

### DIFF
--- a/BIOS/setup.lua
+++ b/BIOS/setup.lua
@@ -1,6 +1,6 @@
 --BIOS Setup Screen
 
-local Handled, love = ... --Handled is passed by BIOS POST, love is available too.
+local Handled = ... --Handled is passed by BIOS POST, love is available too.
 
 local BIOS = Handled.BIOS
 local GPU = Handled.GPU


### PR DESCRIPTION
If love module isn't added as a global to Luacheck, it might show an error.