### PR TITLE
Update repo URL on DiskOS loading screen

### DIFF
--- a/OS/DiskOS/Help/Tips
+++ b/OS/DiskOS/Help/Tips
@@ -16,8 +16,8 @@ You can install PoorOS in the BIOS SETUP, it's just a Lua interpreter.
 You can boot PoorOS directly without installing in the BIOS SETUP.
 You can boot from drive D from the BIOS SETUP, it will execute D:/boot.lua
 You can use the 'SheetToClip' command to store extra spritesheets in your code.
-There's a public github repository for LIKO-12 disk: https://ramilego4game.github.io/LIKO-12-Disks
-LIKO-12 can use post shader, check https://github.com/RamiLego4Game/LIKO-12-Shaders
-Don't forget to give a star in LIKO-12 Github https://github.com/RamiLego4Game/LIKO-12
-LIKO-12 Nightly-Builds are available at https://ramilego4game.github.io/LIKO-12-Nightly
+There's a public github repository for LIKO-12 disk: https://github.com/LIKO-12/Disks
+LIKO-12 can use post shader, check https://github.com/LIKO-12/Shaders
+Don't forget to give a star in LIKO-12 Github https://github.com/LIKO-12/LIKO-12
+LIKO-12 Nightly-Builds are available at https://github.com/LIKO-12/Nightly/releases
 A backup of the .lk12 is created when saving at C:/_backup.lk12

--- a/OS/DiskOS/Help/Whatsnew
+++ b/OS/DiskOS/Help/Whatsnew
@@ -232,7 +232,7 @@
 40. New colored variants of the disk (png) template.
 41. Typofix in GPU.printBackspace.
 42. GPU Matrix stack depth error handling.
-43. New post shaders support, check https://github.com/ramilego4game/LIKO-12-Shaders.
+43. New post shaders support, check https://github.com/LIKO-12/Shaders.
 44. New pattern filling support.
 45. New CPU.openURL.
 46. Added LuaSec to the WEB peripheral.
@@ -242,9 +242,9 @@
 \FOther:\7
 49. New \LIKO-12\7 Icon.
 50. The window icon is now the 16x16 version.
-51. New Nightly Builds: https://ramilego4game.github.io/LIKO-12-Nightly/
+51. New Nightly Builds: https://github.com/LIKO-12/Nightly/releases
 52. Updated github readme.md
-53. New Disks repository: https://ramilego4game.github.io/LIKO-12-Disks
+53. New Disks repository: https://github.com/LIKO-12/Disks
 54. Dropped Windows 64-bit support (temporary).
 55. Luacheck now runs on \LIKO-12\7 Github Repo.
 56. Good amount of updates to the online Documentation.

--- a/OS/DiskOS/Programs/Disks/build.lua
+++ b/OS/DiskOS/Programs/Disks/build.lua
@@ -28,17 +28,17 @@ if targets.win or targets.linux or targets.osx then
     color(7) print("Please download ",false)
     color(6) print("BuildTemplates.zip ",false)
     color(7) print("from ",false)
-    color(6) print("https://github.com/RamiLego4Game/LIKO-12-Nightly/releases")
+    color(6) print("https://github.com/LIKO-12/Nightly/releases")
     color(7) print("\nThen drop them into the window here")
     color(6) print("\nPress any key to open the webpage, or press escape to terminate the build")
     color(7)
-    
+
     for event, a,b,c,d,e,f in pullEvent do
       if event == "keypressed" then
         if a == "escape" then
           return 1, "Build terminated."
         else
-          openURL("https://github.com/RamiLego4Game/LIKO-12-Nightly/releases")
+          openURL("https://github.com/LIKO-12/Nightly/releases")
         end
       elseif event == "filedropped" then
         if not b then return 1, "Failed to read file." end

--- a/OS/DiskOS/System/faketerminal.lua
+++ b/OS/DiskOS/System/faketerminal.lua
@@ -14,7 +14,7 @@ flip() sleep(0.125)
 color(7) print("V".._LIKO_BUILD,(_LIKO_DEV or _LIKO_PRE) and 53 or 43,10)
 cam("translate",0,3) color(12) print("D",false) color(6) print("isk",false) color(12) print("OS") color(6) cam()
 _SystemSheet:draw(60,(fw+1)*6+1,fh+3) flip() sleep(0.125)
-color(6) print("\nhttp://github.com/ramilego4game/liko12")
+color(6) print("\nhttps://liko-12.github.io")
 
 flip() sleep(0.0625)
 

--- a/OS/DiskOS/terminal.lua
+++ b/OS/DiskOS/terminal.lua
@@ -74,7 +74,7 @@ function term.init()
   color(7) print("V".._LIKO_BUILD,(_LIKO_DEV or _LIKO_PRE) and 53 or 43,10)
   cam("translate",0,3) color(12) print("D",false) color(6) print("isk",false) color(12) print("OS") color(6) cam()
   _SystemSheet:draw(60,(fw+1)*6+1,fh+3) flip() sleep(0.125)
-  color(6) print("\nhttps://github.com/LIKO-12/LIKO-12")
+  color(6) print("\nhttps://liko-12.github.io/ ")
 
   flip() sleep(0.0625)
   if fs.exists("D:/autoexec.lua") then

--- a/OS/DiskOS/terminal.lua
+++ b/OS/DiskOS/terminal.lua
@@ -74,7 +74,7 @@ function term.init()
   color(7) print("V".._LIKO_BUILD,(_LIKO_DEV or _LIKO_PRE) and 53 or 43,10)
   cam("translate",0,3) color(12) print("D",false) color(6) print("isk",false) color(12) print("OS") color(6) cam()
   _SystemSheet:draw(60,(fw+1)*6+1,fh+3) flip() sleep(0.125)
-  color(6) print("\nhttp://github.com/ramilego4game/liko12")
+  color(6) print("\nhttps://github.com/LIKO-12/LIKO-12")
 
   flip() sleep(0.0625)
   if fs.exists("D:/autoexec.lua") then

--- a/OS/DiskOS/terminal.lua
+++ b/OS/DiskOS/terminal.lua
@@ -74,7 +74,7 @@ function term.init()
   color(7) print("V".._LIKO_BUILD,(_LIKO_DEV or _LIKO_PRE) and 53 or 43,10)
   cam("translate",0,3) color(12) print("D",false) color(6) print("isk",false) color(12) print("OS") color(6) cam()
   _SystemSheet:draw(60,(fw+1)*6+1,fh+3) flip() sleep(0.125)
-  color(6) print("\nhttps://liko-12.github.io/ ")
+  color(6) print("\nhttps://liko-12.github.io")
 
   flip() sleep(0.0625)
   if fs.exists("D:/autoexec.lua") then

--- a/OS/GameDiskOS/System/faketerminal.lua
+++ b/OS/GameDiskOS/System/faketerminal.lua
@@ -14,7 +14,7 @@ flip() sleep(0.125)
 color(7) print("V".._LIKO_BUILD,(_LIKO_DEV or _LIKO_PRE) and 53 or 43,10)
 cam("translate",0,3) color(12) print("D",false) color(6) print("isk",false) color(12) print("OS") color(6) cam()
 _SystemSheet:draw(60,(fw+1)*6+1,fh+3) flip() sleep(0.125)
-color(6) print("\nhttp://github.com/ramilego4game/liko12")
+color(6) print("\nhttps://liko-12.github.io")
 
 flip() sleep(0.0625)
 


### PR DESCRIPTION
**Type:**
`Typo fix`

**Description:**

Updates the GitHub URL on the loading screen from:

`http://github.com/ramilego4game/liko12`

to:

`https://github.com/LIKO-12/LIKO-12`

**Screenshots:**

<img width="576" alt="screen_shot_2018-09-04_at_8_59_16_pm" src="https://user-images.githubusercontent.com/121322/45070408-f4dc0900-b085-11e8-8ce9-e9a6307365cc.png">

**Modified Section:**
`DiskOS`