### PR TITLE
MacOS accessibility aliases

### DIFF
--- a/Engine/errhand.lua
+++ b/Engine/errhand.lua
@@ -112,7 +112,7 @@ function love.errorhandler(msg)
 				return 1
 			elseif e == "keypressed" and a == "escape" then
 				return 1
-			elseif e == "keypressed" and a == "c" and love.keyboard.isDown("lctrl", "rctrl") then
+			elseif e == "keypressed" and a == "c" and love.keyboard.isDown("lctrl", "rctrl", "lgui", "rgui") then
 				copyToClipboard()
 			elseif e == "touchpressed" then
 				local name = love.window.getTitle()

--- a/OS/DiskOS/APIS/TextUtils.lua
+++ b/OS/DiskOS/APIS/TextUtils.lua
@@ -139,11 +139,11 @@ function TextUtils.textInput(historyTable,preinput)
         end
         blink = true; checkCursor()
       elseif a == "c" then
-        if isKDown("lctrl","rctrl") then
+        if isKDown("lctrl","rctrl", "lgui", "rgui") then
           clipboard(buffer)
         end
       elseif a == "v" then
-        if isKDown("lctrl","rctrl") then
+        if isKDown("lctrl","rctrl", "lgui", "rgui") then
           local paste = clipboard() or ""
 
           for char in string.gmatch(paste..buffer:sub(inputPos,-1),".") do

--- a/OS/DiskOS/APIS/TextUtils.lua
+++ b/OS/DiskOS/APIS/TextUtils.lua
@@ -52,7 +52,7 @@ function TextUtils.textInput(historyTable,preinput)
         table.insert(history, buffer)
         blink = false; checkCursor()
         return buffer
-      elseif a == "backspace" then
+      elseif a == "backspace" and not isKDown("ralt", "lalt") then
         blink = false; checkCursor()
         if buffer:len() > 0 then
           --Remove the character
@@ -78,7 +78,7 @@ function TextUtils.textInput(historyTable,preinput)
           inputPos = inputPos-1
         end
         blink = true; checkCursor()
-      elseif a == "delete" then
+      elseif a == "delete" or (a == "backspace" and isKDown("ralt", "lalt")) then
         blink = false; checkCursor()
         print(buffer:sub(inputPos,-1),false)
         for i=1,buffer:len() do

--- a/OS/DiskOS/Editors/code.lua
+++ b/OS/DiskOS/Editors/code.lua
@@ -860,6 +860,8 @@ ce.keymap = {
   end,
 }
 
+ce.keymap["alt-backspace"] = ce.keymap["delete"]
+
 function ce:entered()
   eapi:drawUI()
   cam("translate",0,1)

--- a/OS/DiskOS/Editors/init.lua
+++ b/OS/DiskOS/Editors/init.lua
@@ -266,7 +266,7 @@ function edit:loop() --Starts the while loop
           key = "alt-" .. key
           sc = "alt-" .. sc
         end
-        if(isKDown("lctrl", "rctrl")) then
+        if(isKDown("lctrl", "rctrl", "lgui", "rgui")) then
           key = "ctrl-" .. key
           sc = "ctrl-" .. sc
         end

--- a/OS/DiskOS/Editors/sprite.lua
+++ b/OS/DiskOS/Editors/sprite.lua
@@ -784,4 +784,6 @@ function se:redrawSPRS() _ = nil
     ["i"] = function() transform(5) end
   }
 
+  se.keymap["alt-backspace"] = se.keymap["delete"]
+
   return se

--- a/OS/DiskOS/Editors/utils.lua
+++ b/OS/DiskOS/Editors/utils.lua
@@ -115,7 +115,7 @@ function utils:newTool(readonly)
             key = "alt-" .. key
             sc = "alt-" .. sc
           end
-          if(isKDown("lctrl", "rctrl", "capslock")) then
+          if(isKDown("lctrl", "rctrl", "lgui", "rgui", "capslock")) then
             key = "ctrl-" .. key
             sc = "ctrl-" .. sc
           end

--- a/OS/DiskOS/terminal.lua
+++ b/OS/DiskOS/terminal.lua
@@ -423,11 +423,11 @@ function term.loop() --Enter the while loop of the terminal
         end
         blink = true; checkCursor()
       elseif a == "c" then
-        if isKDown("lctrl","rctrl") then
+        if isKDown("lctrl","rctrl", "lgui", "rgui") then
           clipboard(buffer)
         end
       elseif a == "v" then
-        if isKDown("lctrl","rctrl") then
+        if isKDown("lctrl","rctrl", "lgui", "rgui") then
           local paste = clipboard() or ""
 
           for char in string.gmatch(paste..buffer:sub(inputPos,-1),".") do

--- a/OS/DiskOS/terminal.lua
+++ b/OS/DiskOS/terminal.lua
@@ -307,7 +307,7 @@ function term.loop() --Enter the while loop of the terminal
           commands = term.updateCommands()
           checkCursor() term.prompt() blink = true cursor("none")
         end
-      elseif a == "backspace" then
+      elseif a == "backspace" and not isKDown("ralt", "lalt") then
         --If an autocomplete suggestion is displayed, erase it
         if autocompleteSuggestions[1] then
           term.refuseSuggestion()
@@ -338,7 +338,7 @@ function term.loop() --Enter the while loop of the terminal
           end
           blink = true; checkCursor()
         end
-      elseif a == "delete" then
+      elseif a == "delete" or (a == "backspace" and isKDown("ralt", "lalt")) then
         --If an autocomplete suggestion is displayed, erase it
         if autocompleteSuggestions[1] then
           term.refuseSuggestion()

--- a/OS/GameDiskOS/APIS/TextUtils.lua
+++ b/OS/GameDiskOS/APIS/TextUtils.lua
@@ -139,11 +139,11 @@ function TextUtils.textInput(historyTable,preinput)
         end
         blink = true; checkCursor()
       elseif a == "c" then
-        if isKDown("lctrl","rctrl") then
+        if isKDown("lctrl","rctrl", "lgui", "rgui") then
           clipboard(buffer)
         end
       elseif a == "v" then
-        if isKDown("lctrl","rctrl") then
+        if isKDown("lctrl","rctrl", "lgui", "rgui") then
           local paste = clipboard() or ""
 
           for char in string.gmatch(paste..buffer:sub(inputPos,-1),".") do

--- a/OS/GameDiskOS/APIS/TextUtils.lua
+++ b/OS/GameDiskOS/APIS/TextUtils.lua
@@ -52,7 +52,7 @@ function TextUtils.textInput(historyTable,preinput)
         table.insert(history, buffer)
         blink = false; checkCursor()
         return buffer
-      elseif a == "backspace" then
+      elseif a == "backspace" and not isKDown("ralt", "lalt") then
         blink = false; checkCursor()
         if buffer:len() > 0 then
           --Remove the character
@@ -78,7 +78,7 @@ function TextUtils.textInput(historyTable,preinput)
           inputPos = inputPos-1
         end
         blink = true; checkCursor()
-      elseif a == "delete" then
+      elseif a == "delete" or (a == "backspace" and isKDown("ralt", "lalt")) then
         blink = false; checkCursor()
         print(buffer:sub(inputPos,-1),false)
         for i=1,buffer:len() do

--- a/OS/PoorOS/boot.lua
+++ b/OS/PoorOS/boot.lua
@@ -34,7 +34,7 @@ function input()
         return t --Return the text
       elseif a == "escape" then
         return false --User canceled text input.
-      elseif a == "v" and Keyboard.isKDown("lctrl","rctrl") then
+      elseif a == "v" and Keyboard.isKDown("lctrl","rctrl", "lgui", "rgui") then
         CPU.triggerEvent("textinput",CPU.clipboard())
       end
     elseif event == "touchpressed" then


### PR DESCRIPTION
## Type
`Improvement`

## Description
Add aliases that map the Command key on MacOS to the Ctrl key.

This shouldn't be harmful to users in other OSes since the Windows key it's generally mapped to an OS level action which has precedence. Also you can continue using Ctrl without issues

Add aliases that map Alt+Backspace to the Delete key which doesn't exist in common Mac keyboards

Fixes #210

## Modified Section
Mainly the editors and terminal applications in `DiskOS` `GameDiskOS` and `PoorOS` but also the error handler in the `Engine`