### PR TITLE
Drop unnecessary colon in README headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ DiskOS provides an environment with basic command line programs and visual game 
 
 The created games and programs are saved as disk files that can be easily shared to friends or anyone else.
 
-# Website:
+# Website
 
 Please visit the website for more information about LIKO-12, including features list, screenshots, and documentation: [https://liko-12.github.io/](https://liko-12.github.io/)


### PR DESCRIPTION
**Type:**  
Bug fix

**Description:**
The colon in the "Website" subheading in the README is unnecessary, this PR drops it.

**Modified Section:**
Docs
