### PR TITLE
Fixed a coloration syntax typo

### DIFF
--- a/OS/DiskOS/Help/Terminal
+++ b/OS/DiskOS/Help/Terminal
@@ -1,5 +1,5 @@
 \B> The Terminal:\7
-It's a command prompt waiting for you to enter commands in, like the /9help/7 command that you did just use.
+It's a command prompt waiting for you to enter commands in, like the \9help\7 command that you did just use.
 
 It takes the command name first, then the arguments if there's any.
 


### PR DESCRIPTION
**Type:**
`Typo fix`

**Description:**
The "help Terminal" command displays /7help/9 instead of a colored "help" because of a syntax error (slashes being used instead of backslashes)

**Screenshots:**
![Screenshot of the error, seen when typing "help Terminal"](https://user-images.githubusercontent.com/32939301/67757842-d6c92900-fa3c-11e9-8e08-3a7b306ba302.png)

**Modified Section:**
`DiskOS`

