### PR TITLE
Added SWEETIE-16 Palette & Fixed BIOS Setup Typo

### DIFF
--- a/BIOS/setup.lua
+++ b/BIOS/setup.lua
@@ -345,7 +345,7 @@ local showAppdataEvents = {
     GPU.color(7)
     GPU.print(appdataPath,0,sh*0.45-(fh-1)/2,sw,"center")
     
-    printCenterBG("Press "..(mobile and "the green button" or "escape").." to return back",sh*0.66,6,5)
+    printCenterBG("Press "..(mobile and "the red button" or "escape").." to return back",sh*0.66,6,5)
   end,
   
   keypressed = function(self,key)
@@ -381,7 +381,7 @@ local wipeADriveEvents = {
     
     drawOptions(self.options,self.selectedOption)
     
-    printBG("\xC2 Press "..(mobile and "the green button" or "escape").." to return back",2,sh-16,0)
+    printBG("\xC2 Press "..(mobile and "the red button" or "escape").." to return back",2,sh-16,0)
   end,
   
   keypressed = function(self,key,_,isrepeat)
@@ -476,7 +476,7 @@ do
     
     printBG("\xC3 Some operating systems won't work",2,sh-16-(fh+2)*2,0)
     printBG("  if not installed on drive C.",2,sh-16-fh-2,0)
-    printBG("\xC2 Press "..(mobile and "the green button" or "escape").." to return back",2,sh-16,0)
+    printBG("\xC2 Press "..(mobile and "the red button" or "escape").." to return back",2,sh-16,0)
   end
   
   function osInstallerEvents:keypressed(key,_,isrepeat)

--- a/OS/DiskOS/Demos/palette.lk12
+++ b/OS/DiskOS/Demos/palette.lk12
@@ -6,6 +6,8 @@ local W, H = screenSize()
 
 local PALETTES =
 {
+ {name="SWEETIE-16", data="1a1c2c5d275db13e53ef7d57ffcd75a7f07038b76425717929366f3b5dc941a6f673eff7333c57566c8694b0c2f4f4f4"},
+
  {name="DB16",  data="140c1c44243430346d4e4a4e854c30346524d04648757161597dced27d2c8595a16daa2cd2aa996dc2cadad45edeeed6"},
  {name="PICO-8",data="0000007e25531d2b535f574fab5236008751ff004d83769cff77a8ffa300c2c3c700e756ffccaa29adfffff024fff1e8"},
  {name="ARNE16",data="0000001b2632005784493c2ba4642244891abe26332f484e31a2f2eb89319d9d9da3ce27e06f8bb2dceff7e26bffffff"},

--- a/OS/DiskOS/Demos/palette.lk12
+++ b/OS/DiskOS/Demos/palette.lk12
@@ -7,7 +7,6 @@ local W, H = screenSize()
 local PALETTES =
 {
  {name="SWEETIE-16", data="1a1c2c5d275db13e53ef7d57ffcd75a7f07038b76425717929366f3b5dc941a6f673eff7333c57566c8694b0c2f4f4f4"},
-
  {name="DB16",  data="140c1c44243430346d4e4a4e854c30346524d04648757161597dced27d2c8595a16daa2cd2aa996dc2cadad45edeeed6"},
  {name="PICO-8",data="0000007e25531d2b535f574fab5236008751ff004d83769cff77a8ffa300c2c3c700e756ffccaa29adfffff024fff1e8"},
  {name="ARNE16",data="0000001b2632005784493c2ba4642244891abe26332f484e31a2f2eb89319d9d9da3ce27e06f8bb2dceff7e26bffffff"},


### PR DESCRIPTION
So, I **have 2 things** for you:
------------------------------------------------------------------------
**1st Thing**:
Added [SWEETIE-16](https://lospec.com/palette-list/sweetie-16) color palette
------------------------------------------------------------------------
**Type:**
`New feature`, `Improvement`

**Description:**
Added [SWEETIE-16](https://lospec.com/palette-list/sweetie-16) color palette by [@GrafxKid](https://twitter.com/grafxkid)

**Screenshots:**
![Screenshot_20210303-163033](https://user-images.githubusercontent.com/57618009/109784862-165de180-7c3e-11eb-8ee8-2d985fd9f4d0.jpg)

**Modified Section:**
`DiskOS`

**2nd Thing**:
Fixed BIOS Setup Typo
------------------------------------------------------------------------
**Type:**
`Typo Fix`

**Description:**
Fixed typo while in:
1. "APPData Path" screen,
2. "Wipe a drive" screen, and
3. "OS Installer" screen.

**Screenshots:**
Unfixed "APPData Path" screen:
![Screenshot_20210303-225142](https://user-images.githubusercontent.com/57618009/109832854-5ab7a480-7c73-11eb-8f8f-1de5b650770d.jpg)
Unfixed "Wipe a drive" screen:
![Screenshot_20210303-225204](https://user-images.githubusercontent.com/57618009/109833080-8dfa3380-7c73-11eb-979d-6d67e138fd6f.jpg)
Unfixed "OS Installer" screen:
![Screenshot_20210303-225220](https://user-images.githubusercontent.com/57618009/109833254-b1bd7980-7c73-11eb-9020-89e2823ca37d.jpg)

**Modified Section:**
`BIOS`

Please verify that you validate these points:

- [x] indentation is made with 2 spaces
- [x] your pull request contains only changes intended (no refactoring, line return added, ... that could make code review harder. Make another one if you think it is needed...)
- [x] update the documentation, if needed.

------------------------------------------------------------------------